### PR TITLE
fix: add custom resize event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2763,9 +2763,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001485",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001485.tgz",
-      "integrity": "sha512-8aUpZ7sjhlOyiNsg+pgcrTTPUXKh+rg544QYHSvQErljVEKJzvkYkCR/hUFeeVoEfTToUtY9cUKNRC7+c45YkA==",
+      "version": "1.0.30001559",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz",
+      "integrity": "sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==",
       "dev": true,
       "funding": [
         {

--- a/src/app.js
+++ b/src/app.js
@@ -143,6 +143,12 @@ H5P.CategoryTask = (function () {
         return;
       }
       this.addBreakPoints(this.wrapper);
+
+      // Waint until css breakpints have been applied and layout has
+      // been run by browser before triggering resize.
+      requestAnimationFrame(() => {
+        this.trigger('resize');
+      });
     };
 
     /**
@@ -165,7 +171,9 @@ H5P.CategoryTask = (function () {
 
     this.getRect = this.getRect.bind(this);
     this.resize = this.resize.bind(this);
-    this.on('resize', this.resize);
+    // Use custom resizecontenttype event to avoid triggering resize
+    // until breakpoints have been applied.
+    this.on('resizecontenttype', this.resize);
   }
 
   // Inherit prototype properties

--- a/src/components/Surface/Surface.js
+++ b/src/components/Surface/Surface.js
@@ -321,7 +321,11 @@ function Surface() {
   };
 
   useEffect(() => {
-    context.trigger('resize');
+    requestAnimationFrame(() => {
+      // Trigger custom event instead of H5P event to avoid
+      // triggering resize until breakpoints have been applied.
+      context.trigger('resizecontenttype');
+    });
   }, [state.argumentsList, state.categories]);
 
   const {


### PR DESCRIPTION
Need to trigger resize after breakpoints have been applied

<img width="701" alt="Skjermbilde 2023-11-01 kl  10 21 54" src="https://github.com/NDLANO/h5p-category-task/assets/35261194/e93d7fcc-0421-4cd0-9709-9ae8c9db9090">
