### PR TITLE
feat: design upgrades

### DIFF
--- a/src/components/Argument/Argument.js
+++ b/src/components/Argument/Argument.js
@@ -115,7 +115,7 @@ function ArgumentLayout({
             className={'h5p-category-task-argument-actions'}
             aria-label={'See available actions'}
             aria-expanded={showPopover}
-            aria-controls={menuId}
+            aria-controls={showPopover ? menuId : undefined}
             onClick={toggle}
             type={'button'}
           >

--- a/src/components/Argument/Argument.js
+++ b/src/components/Argument/Argument.js
@@ -20,6 +20,8 @@ function Argument({
 
   const [showPopover, togglePopover] = useState(false);
 
+  const actionMenuId = `action-menu-${argument.id}_${H5P.createUUID()}`;
+
   function toggle() {
     togglePopover((prevState) => !prevState);
   }
@@ -52,6 +54,8 @@ function Argument({
       activeDraggable={isDragEnabled && isDragging}
       isDragEnabled={isDragEnabled}
       statementDisplay={displayStatement}
+      showPopover={showPopover}
+      menuId={actionMenuId}
       toggle={toggle}
     />
   );
@@ -59,6 +63,7 @@ function Argument({
   if (Array.isArray(actions) && actions.length > 0 && refReady) {
     argumentLayout = (
       <ActionMenu
+        menuId={actionMenuId}
         actions={actions}
         show={showPopover}
         handleClose={closePopover}
@@ -70,7 +75,7 @@ function Argument({
   }
 
   return (
-    <div id={getDnDId(argument)} aria-expanded={showPopover} ref={innerRef}>
+    <div id={getDnDId(argument)} ref={innerRef}>
       {argumentLayout}
     </div>
   );
@@ -90,6 +95,8 @@ function ArgumentLayout({
   activeDraggable,
   isDragEnabled,
   statementDisplay,
+  showPopover,
+  menuId,
   toggle,
 }) {
   return (
@@ -107,6 +114,8 @@ function ArgumentLayout({
           <button
             className={'h5p-category-task-argument-actions'}
             aria-label={'See available actions'}
+            aria-expanded={showPopover}
+            aria-controls={menuId}
             onClick={toggle}
             type={'button'}
           >

--- a/src/components/Argument/components/ActionMenu.js
+++ b/src/components/Argument/components/ActionMenu.js
@@ -10,6 +10,7 @@ function ActionMenu(props) {
   const { translate } = context;
 
   const {
+    menuId,
     children,
     show,
     handleClose,
@@ -137,6 +138,7 @@ function ActionMenu(props) {
       containerStyle={{ position: 'absolute', top: '56px' }}
       content={() => (
         <div
+          id={menuId}
           className={'h5p-category-task-popover-actionmenu'}
           role={'dialog'}
           aria-labelledby={'actionMenuTitle'}

--- a/src/components/Argument/components/EditableArgument.js
+++ b/src/components/Argument/components/EditableArgument.js
@@ -15,7 +15,7 @@ function EditableArgument(props) {
     }
   }, []);
 
-  const handleClick = () => {
+  const startEditing = () => {
     if (inEditMode === false) {
       toggleEditMode(true);
       inputRef.current.value = props.argument;
@@ -23,23 +23,19 @@ function EditableArgument(props) {
     }
   };
 
-  const handleBlur = () => {
+  const stopEditing = () => {
     toggleEditMode(false);
   };
 
-  const handleKeyUp = (event) => {
-    if (event.keyCode === 13) {
-      if ( inEditMode ) {
-        handleBlur();
-      }
-      else {
-        handleClick();
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      if (inEditMode) {
+        stopEditing();
       }
     }
   };
 
   const id = 'es_' + props.idBase;
-  const labelId = 'label_' + id;
   const inputId = 'input_' + id;
 
   /*
@@ -49,41 +45,37 @@ function EditableArgument(props) {
    *       is ARIA labelling handled that way?
    */
   return (
-    <div
-      role={'textbox'}
-      tabIndex={0}
-      onClick={handleClick}
-      className={'h5p-category-task-editable-container'}
-      onKeyUp={handleKeyUp}
-      aria-labelledby={labelId}
-    >
-      <div>
-        <label
-          title={props.argument}
-          htmlFor={inputId}
-          id={labelId}
-          className={classnames('h5p-category-task-editable', {
-            'hidden': inEditMode === false,
-          })}
-        >
-          <span className={'visible-hidden'}>Argument</span>
-          <input
-            className={'h5p-category-task-editable'}
-            ref={inputRef}
-            onBlur={handleBlur}
-            onChange={debounce(() => props.onBlur(inputRef.current.value), 200)}
-            aria-label={'Edit argument ' + props.argument}
-            id={inputId}
-          />
-        </label>
-        <p
-          className={classnames('h5p-category-task-noneditable', {
-            'hidden': inEditMode === true,
-          })}
-        >
-          {props.argument}
-        </p>
-      </div>
+    <div className={'h5p-category-task-editable-container'}>
+      <button
+        className={'h5p-category-task-editable-button'}
+        onClick={startEditing}
+      >
+        <span className={'visible-hidden'}>{'Edit argument' + props.argument}</span>
+      </button>
+      <label
+        title={props.argument}
+        htmlFor={inputId}
+        className={classnames('h5p-category-task-editable', {
+          'hidden': inEditMode === false,
+        })}
+      >
+        <span className={'visible-hidden'}>Argument</span>
+        <input
+          className={'h5p-category-task-editable'}
+          ref={inputRef}
+          onBlur={stopEditing}
+          onChange={debounce(() => props.onBlur(inputRef.current.value), 200)}
+          onKeyDown={handleKeyDown}
+          id={inputId}
+        />
+      </label>
+      <p
+        className={classnames('h5p-category-task-noneditable', {
+          'hidden': inEditMode === true,
+        })}
+      >
+        {props.argument}
+      </p>
     </div>
   );
 }

--- a/src/components/Argument/components/EditableArgument.js
+++ b/src/components/Argument/components/EditableArgument.js
@@ -52,7 +52,9 @@ function EditableArgument(props) {
   return (
     <div className={'h5p-category-task-editable-container'}>
       <button
-        className={'h5p-category-task-editable-button'}
+        className={classnames('h5p-category-task-editable-button', {
+          'h5p-category-task-editable-button--editing': inEditMode === true,
+        })}
         onClick={startEditing}
       >
         <span className={'visible-hidden'}>{'Edit argument ' + props.argument}</span>

--- a/src/components/Argument/components/EditableArgument.js
+++ b/src/components/Argument/components/EditableArgument.js
@@ -27,6 +27,11 @@ function EditableArgument(props) {
     toggleEditMode(false);
   };
 
+  /**
+   * Handle keydown events.
+   * KeyDown is used instead of KeyUp to prevent focused input to be blurred
+   * when arguments are added with the enter key.
+   */
   const handleKeyDown = (event) => {
     if (event.key === 'Enter') {
       if (inEditMode) {
@@ -50,7 +55,7 @@ function EditableArgument(props) {
         className={'h5p-category-task-editable-button'}
         onClick={startEditing}
       >
-        <span className={'visible-hidden'}>{'Edit argument' + props.argument}</span>
+        <span className={'visible-hidden'}>{'Edit argument ' + props.argument}</span>
       </button>
       <label
         title={props.argument}

--- a/src/components/CategoryTask.scss
+++ b/src/components/CategoryTask.scss
@@ -572,6 +572,7 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   width: 100%;
   border: 2px solid #dbe2e8;
   border-radius: $borderRadius;
+  margin-bottom: 1.5rem !important;
 }
 
 .h5p-category-task-unprocessed-argument-list {
@@ -822,7 +823,7 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
 
 
 .h5p-category-task-category {
-  margin-bottom: 0.7rem;
+  margin-bottom: 1rem;
   position: relative;
 }
 

--- a/src/components/CategoryTask.scss
+++ b/src/components/CategoryTask.scss
@@ -511,7 +511,7 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
     line-height: 1.5625rem;
     text-shadow: 2px 1px 3px rgba(28,28,28,0.5);
     border-radius: $borderRadius $borderRadius 0 0;
-    background-color: #2880d0;
+    background-color: #2679C5;
     color: #ffffff;
     font-size: 1.125rem;
   }

--- a/src/components/CategoryTask.scss
+++ b/src/components/CategoryTask.scss
@@ -452,6 +452,15 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
   justify-content: flex-start;
   align-items: center;
   padding: 0.3em 0.6em;
+  position: relative;
+
+  .h5p-category-task-editable-button {
+    background-color: transparent;
+    background-image: none;
+    border: 0;
+    inset: 0;
+    position: absolute;
+  }
 
   label,
   div {

--- a/src/components/CategoryTask.scss
+++ b/src/components/CategoryTask.scss
@@ -458,8 +458,13 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
     background-color: transparent;
     background-image: none;
     border: 0;
+    cursor: inherit;
     inset: 0;
     position: absolute;
+  }
+
+  .h5p-category-task-editable-button--editing {
+    cursor: text;
   }
 
   label,


### PR DESCRIPTION
- Adjusts the text contrast in the category headers.
- Fixes wrong use of ARIA attribute where aria-expanded was not placed on the associated button.
- Adjusts the spacing between the sections. The space between the uncategorized container and the category containers was very small, made it more similar to the spacing in Discussion. 
- Fixes issue with duplicate labels used. EditableArgument had both a textbox and input that used the same label when though the input was placed inside the textbox. Did tidy up the structure a bit and removed the textbox role and used a button instead to allow the onClick function to make the input editable. A button is also more appropriate for the function that is used as it requires the same action from the user to enable the input, rather than screen readers saying that it is a input/textbox and misguiding the users.