### PR TITLE
feat: right align actionmenu

### DIFF
--- a/src/components/Argument/components/ActionMenu.js
+++ b/src/components/Argument/components/ActionMenu.js
@@ -152,7 +152,7 @@ function ActionMenu(props) {
       padding={0}
       reposition={false}
       parentElement={parentElement}
-      containerStyle={{ position: 'absolute', top: '56px' }}
+      containerStyle={{ position: 'absolute', top: `${parentBox.height}px` }}
       content={() => (
         <div
           id={menuId}

--- a/src/components/CategoryTask.scss
+++ b/src/components/CategoryTask.scss
@@ -103,6 +103,13 @@ article, aside, details, figcaption, figure, footer, header, main, menu, nav, se
       display: flex;
     }
   }
+
+  .h5p-category-task-right-aligned {
+    .h5p-category-task-actionmenu {
+      left: unset !important;
+      right: 0;
+    }
+  }
 }
 
 .h5p-large-tablet-size,

--- a/src/components/Surface/Surface.js
+++ b/src/components/Surface/Surface.js
@@ -14,12 +14,14 @@ import Column from '../DragAndDrop/Column';
 import Element from '../DragAndDrop/Element';
 import Summary from '../Summary/Summary';
 import Dropzone from '../DragAndDrop/Dropzone';
+import classnames from 'classnames';
 import {
   ActionMenuDataObject,
   ArgumentDataObject,
   CategoryDataObject,
   clone,
   getDnDId,
+  isEven,
 } from '../utils';
 
 /**
@@ -603,12 +605,13 @@ function Surface() {
         >
           {state.categories
             .filter((category) => category.isArgumentDefaultList)
-            .map((category) => (
+            .map((category, index) => (
               <div key={category.id}>
                 <Column
-                  additionalClassName={
-                    'h5p-category-task-unprocessed-argument-list'
-                  }
+                  additionalClassName={classnames(
+                    'h5p-category-task-unprocessed-argument-list', {
+                    'h5p-category-task-right-aligned': isEven(index + 1),
+                  })}
                   droppableId={getDnDId(category)}
                   disableDrop={true}
                   connectedArguments={category.connectedArguments}
@@ -636,7 +639,7 @@ function Surface() {
         </Category>
         {state.categories
           .filter((category) => !category.isArgumentDefaultList)
-          .map((category) => (
+          .map((category, index) => (
             <Category
               key={category.id}
               categoryId={getDnDId(category)}
@@ -654,7 +657,9 @@ function Surface() {
               }
             >
               <Column
-                additionalClassName={'h5p-category-task-argument-list'}
+                additionalClassName={classnames('h5p-category-task-argument-list', {
+                  'h5p-category-task-right-aligned': isEven(index + 1),
+                })}
                 droppableId={getDnDId(category)}
                 disableDrop={
                   state.actionDropActive && !category.actionTargetContainer

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -269,3 +269,13 @@ export function getRatio(container) {
 export function clone(object) {
   return JSON.parse(JSON.stringify(object));
 }
+
+/**
+ * Check if a number is even
+ * 
+ * @param {number} number
+ * @returns {boolean}
+ */
+export function isEven(number) {
+  return number % 2 === 0;
+}


### PR DESCRIPTION
- Right aligns the actionmenu of arguments that are placed on the right side of the iframe, so that the menu doesn't go out of the iframe. This could occur when a category has a very long name, when the screen size is small, or when the font size is sized up.
- Places the actionmenu below the argument always, not only when the argument goes over one line. 

Before PR:
<img width="718" alt="Skjermbilde 2023-11-10 kl  12 48 07" src="https://github.com/NDLANO/h5p-category-task/assets/35261194/2feca701-b128-41ba-8fc0-23dcb79d8e35">


After PR:
<img width="719" alt="Skjermbilde 2023-11-10 kl  12 47 25" src="https://github.com/NDLANO/h5p-category-task/assets/35261194/fe255c97-ae12-4764-943e-7d0e8387ce9a">
 